### PR TITLE
Update CMD in Dockerfile to use 4 workers

### DIFF
--- a/validator/proxy/Dockerfile
+++ b/validator/proxy/Dockerfile
@@ -8,4 +8,5 @@ RUN pip install --no-cache-dir -r requirements.txt
 COPY *.py ./
 COPY --from=loggers *.py loggers/
 
-CMD ["uvicorn", "api:app", "--host", "0.0.0.0", "--port", "8000"]
+#CMD ["uvicorn", "api:app", "--host", "0.0.0.0", "--port", "8000"]
+CMD ["uvicorn", "api:app", "--host", "0.0.0.0", "--port", "8000", "--workers", "4"]


### PR DESCRIPTION
This change allows the proxy to handle 4 inference requests at one time. This allows the agent to add parallelism of the inference and speed up the agent run.