### PR TITLE
add semaphore and session to reduce

### DIFF
--- a/validator/proxy/chutes_client.py
+++ b/validator/proxy/chutes_client.py
@@ -21,6 +21,8 @@ TIMEOUT = 300
 MAX_RETRIES = 5
 BACKOFF_FACTOR = 1.5
 
+# Global session for connection reuse (one per worker process)
+SESSION = requests.Session()
 
 def call_chutes(
     request: InferenceRequest,
@@ -36,7 +38,7 @@ def call_chutes(
     if not api_key:
         api_key = CHUTES_API_KEY
 
-    headers = {"Authorization": f"Bearer {CHUTES_API_KEY}"}
+    headers = {"Authorization": f"Bearer {api_key}"}
     payload_dict = request.model_dump()
     resp = None
 
@@ -45,7 +47,7 @@ def call_chutes(
     for attempt in range(1, MAX_RETRIES + 1):
         try:
             logger.info(f"Sending request to Chutes. Attempt: {attempt}")
-            resp = requests.post(
+            resp = SESSION.post(
                 CHUTES_API_URL,
                 headers=headers,
                 json=payload_dict,


### PR DESCRIPTION
This pull request introduces improvements to concurrency handling and HTTP connection management in the inference proxy service. The main changes are the addition of a semaphore to limit concurrent inference requests per worker and the use of a global HTTP session for efficient connection reuse.

Concurrency improvements:

* Added an `asyncio.Semaphore` (`INFER_CONCURRENCY`) to limit the number of concurrent inference requests handled per worker, preventing resource exhaustion and improving stability. The semaphore is used in the `/inference` endpoint to wrap each request. [[1]](diffhunk://#diff-6b0070c056b6e750cb42a8895b8cc02e7675baf8c49abe96afe0f4429716eed8R27-R29) [[2]](diffhunk://#diff-6b0070c056b6e750cb42a8895b8cc02e7675baf8c49abe96afe0f4429716eed8R38)

HTTP connection management:

* Introduced a global `requests.Session` object (`SESSION`) for HTTP requests to the Chutes API, enabling connection reuse and reducing overhead. All requests to the Chutes API now use this session. [[1]](diffhunk://#diff-2ab66f9db5a6430790aa1159b6a78e1db6f88fa42b594807021458c9f8c901ffR24-R25) [[2]](diffhunk://#diff-2ab66f9db5a6430790aa1159b6a78e1db6f88fa42b594807021458c9f8c901ffL48-R50)

Other improvements:

* Fixed a bug where the `Authorization` header always used the global `CHUTES_API_KEY` instead of the resolved `api_key`, ensuring the correct key is used for each request.